### PR TITLE
Add Django 2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(fname):
 
 setuptools.setup(
     name='wirecloud-keycloak',
-    version='0.2.0',
+    version='0.2.1',
     author="FICODES",
     author_email="contact@ficodes.com",
     description="WireCloud extension supporting authentication with Keycloak IDM",

--- a/wirecloud/keycloak/views.py
+++ b/wirecloud/keycloak/views.py
@@ -21,7 +21,7 @@ import json
 
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse, HttpResponseRedirect
 from django.views.decorators.http import require_GET
 


### PR DESCRIPTION
This PR adds support for Django 2 as WireCloud 1.4 is moving to use this version of Django. In any case, this PR adds Django 2 support maintaining Django 1.10+ compatibility. This means that the plugin will still be compatible with WireCloud 1.3+. In fact, the change itself should be compatible with WireCloud 1.0+, but we have not tested the plugin with those versions of WireCloud so maybe there is some other incompatibility.