### PR TITLE
Create admin group to allow admin-only dashboards

### DIFF
--- a/wirecloud/keycloak/social_auth_backend.py
+++ b/wirecloud/keycloak/social_auth_backend.py
@@ -82,7 +82,7 @@ class KeycloakOAuth2(BaseOAuth2):
                 roles = response['resource_access'][self.CLIENT_ID]['roles']
 
         superuser = any(role.strip().lower() == "admin" for role in roles)
-        group_roles = [role.strip().lower() for role in roles if role.strip().lower() != "admin"]
+        group_roles = [role.strip().lower() for role in roles]
 
         return {
             'username': response.get('preferred_username'),

--- a/wirecloud/keycloak/tests/social_backend.py
+++ b/wirecloud/keycloak/tests/social_backend.py
@@ -162,7 +162,7 @@ class KeycloakSocialAuthBackendTestCase(TestCase):
         }
         details['is_superuser'] = True
         details['is_staff'] = True
-        details['roles'] = ['manager']
+        details['roles'] = ['admin', 'manager']
 
         self._test_get_user_details(resource, details)
 
@@ -180,6 +180,7 @@ class KeycloakSocialAuthBackendTestCase(TestCase):
         }
         details['is_superuser'] = True
         details['is_staff'] = True
+        details['roles'] = ['admin']
 
         self._test_get_user_details(resource, details)
 


### PR DESCRIPTION
With current implementation admin role is not propagated to create a group, so that prevents having dashboard shared only with users with admin role.