### PR TITLE
Add support for social Django 5.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 wirecloud>=1.2.0,<1.5
-social-auth-core[openidconnect]
-social-auth-app-django
+social-auth-core[openidconnect]<5.0.0
+social-auth-app-django<6.0.0

--- a/wirecloud/keycloak/utils.py
+++ b/wirecloud/keycloak/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2019 Future Internet Consulting and Development Solutions S.L.
+# Copyright (c) 2019-2021 Future Internet Consulting and Development Solutions S.L.
 
 # This file is part of Wirecloud Keycloak plugin.
 
@@ -24,8 +24,14 @@ def build_version_hash():
 
 
 def build_backend():
-    from social_django.utils import BACKENDS, get_backend, load_strategy
-    return get_backend(BACKENDS, 'keycloak_oidc')(load_strategy())
+    try:
+        # Social auth < 4.1.0
+        from social_django.utils import BACKENDS, get_backend, load_strategy
+        return get_backend(BACKENDS, "keycloak_oidc")(load_strategy())
+    except ImportError:
+        # Social auth 4.1.0 onwards
+        from social_django.utils import load_strategy
+        return load_strategy().get_backend("keycloak_oidc")
 
 
 def load_strategy():

--- a/wirecloud/keycloak/utils.py
+++ b/wirecloud/keycloak/utils.py
@@ -24,13 +24,8 @@ def build_version_hash():
 
 
 def build_backend():
-    from social_django.utils import BACKENDS, get_backend,  load_strategy
+    from social_django.utils import BACKENDS, get_backend, load_strategy
     return get_backend(BACKENDS, 'keycloak_oidc')(load_strategy())
-
-
-def build_simple_backend():
-    from social_django.utils import BACKENDS, get_backend
-    return get_backend(BACKENDS, 'keycloak_oidc')
 
 
 def load_strategy():
@@ -42,9 +37,11 @@ def get_social_auth_model():
     from social_django.models import UserSocialAuth
     return UserSocialAuth
 
+
 def get_user_model():
     from django.contrib.auth.models import User
     return User
+
 
 def get_group_model():
     from django.contrib.auth.models import Group


### PR DESCRIPTION
Current version of the `wirecloud-keycloak` plugin is not working raising the following exception:

```
ImportError: cannot import name 'BACKENDS'
```

This PR fixes this problem, provides some sane version limits as well as it make some clean ups related to the code managing social auth backends.