### PR TITLE
Add support for Keycloak 18+

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ These settings include:
 * `SOCIAL_AUTH_KEYCLOAK_OIDC_SECRET`: Client secret of the WireCloud application
 * `SOCIAL_AUTH_KEYCLOAK_OIDC_GLOBAL_ROLE`: Whether the admin role is taken from the realm instead of from the client (default: `False`)
 
+If you're using Keycloak 17 or earlier, `SOCIAL_AUTH_KEYCLOAK_OIDC_URL` should include the `/auth` suffix, e.g. `https://keycloak.example.com/auth`.
+
 This plugin is able to map Keycloak roles into WireCloud groups. To enable it, you should enable the `realm roles` and the `client roles` mappings either for the wirecloud application or for the `roles` scope. This mapping should include role information on the ID token.
 
 Finally, to add backchannel logout support (Single Sign Off), the following code: `url('', include('wirecloud.keycloak.urls')),` has to be added inside the urlpatterns list defined on your `urls.py` file. Once done this, you can access the Keycloak console to configure the **Admin URL** of the WireCloud application to point into the following url: `http(s)://wirecloud.example.com/keycloak`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 wirecloud>=1.2.0,<1.5
 social-auth-core[openidconnect]<5.0.0
 social-auth-app-django<6.0.0
+python-jose<4.0.0

--- a/wirecloud/keycloak/social_auth_backend.py
+++ b/wirecloud/keycloak/social_auth_backend.py
@@ -32,7 +32,7 @@ from wirecloud.keycloak.utils import get_user_model, get_group_model
 # Get an instance of a logger
 logger = logging.getLogger(__name__)
 
-KEYCLOAK_OIDC_ENDPOINT = 'auth/realms/{}'
+KEYCLOAK_OIDC_ENDPOINT = 'realms/{}'
 
 
 class KeycloakOpenIdConnect(OpenIdConnectAuth):


### PR DESCRIPTION
This PR adds support for Keycloak 18+, which removes the `/auth` path prefix. This is a breaking change, but shouldn't be an issue since we're on v0.
It also marks `python-jose` as a dependency 